### PR TITLE
Add links to shared_configs files

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -25,7 +25,8 @@ Capistrano::OneTimeKey.generate_one_time_key!
 # set :pty, true
 
 # Default value for :linked_files is []
-#append :linked_files, 'config/settings.yml'
+append :linked_files, 'config/config.sh'
+append :linked_files, 'java/src/main/resources/server.conf'
 
 # Default value for linked_dirs is []
 append :linked_dirs, 'log'


### PR DESCRIPTION
I manually put the shared config files in place and tested the deployment with these linked files and it works, i.e. the capistrano console reports success in linking the files:
```
00:06 deploy:symlink:linked_files
      01 mkdir -p /opt/app/ld4p/ld4p-marc21-to-xml/releases/20170308200114/config /opt/app/ld4p/ld4p-marc21-to-xml/releases/20170308200114/java/src/main/resources
    ✔ 01 ld4p@sul-ld4p-converter-dev.stanford.edu 0.043s
      02 rm /opt/app/ld4p/ld4p-marc21-to-xml/releases/20170308200114/config/config.sh
    ✔ 02 ld4p@sul-ld4p-converter-dev.stanford.edu 0.033s
      03 ln -s /opt/app/ld4p/ld4p-marc21-to-xml/shared/config/config.sh /opt/app/ld4p/ld4p-marc21-to-xml/releases/20170308200114/config/config.sh
    ✔ 03 ld4p@sul-ld4p-converter-dev.stanford.edu 0.038s
      04 ln -s /opt/app/ld4p/ld4p-marc21-to-xml/shared/java/src/main/resources/server.conf /opt/app/ld4p/ld4p-marc21-to-xml/releases/20170308200114/java/src/main/resources/server.conf
    ✔ 04 ld4p@sul-ld4p-converter-dev.stanford.edu 0.036s
```

The important thing is that this file linking occurs before the maven build, so the build includes the private `server.conf` file now.

We are waiting on resolving some details on how to deploy the shared_configs files to the converter-dev box, but those details can be resolved later.  For now, given that I put the files in place manually, it is working and we can proceed with this PR.  The details in this PR do not really depend on how we resolve the dev-ops deployment details for the shared_configs file.