### PR TITLE
Package JAR into lib directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ buildNumber.properties
 java/src/main/resources/server.conf
 java/log
 
+# Packaged JAR file
+lib/xform-marc21-to-xml-jar-with-dependencies.jar
+
 # MARC-XML output files
 data/MarcXML/*.xml
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -51,6 +51,7 @@
                 <configuration>
                     <!--<descriptor>src/assembly/bin.xml</descriptor>-->
                     <descriptor>src/assembly/jar-with-dependencies.xml</descriptor>
+                    <outputDirectory>../lib</outputDirectory>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Package the java code and dependencies into the ./lib directory; i.e. `mvn package` will create the `lib/xform-marc21-to-xml-jar-with-dependencies.jar` file.

It is currently essential for a system to build and package the code using a custom file for the Auth-DB config (i.e. it should provide a `java/src/main/resources/server.conf` file before building the project).  To move away from this requirement to have a custom `server.conf` file during the build, we need a way to provide it at runtime.  This could be enabled by adding a command line option to the MarcToXML class, so it could be called with an option to read from any config file at runtime.  This can be addressed in another PR for https://github.com/sul-dlss/ld4p-marc21-to-xml/issues/22