### PR TITLE
Fix test script

### DIFF
--- a/bin/marc21_to_marcxml.sh
+++ b/bin/marc21_to_marcxml.sh
@@ -22,6 +22,10 @@ echo "Logging conversion to: ${log_file}"
 
 # Java library, built from ./java sources and copied to ./lib
 jar="${LD4P_LIB}/xform-marc21-to-xml-jar-with-dependencies.jar"
+if [ ! -f "$jar" ]; then
+    echo "ERROR: cannot find JAR: $jar"
+    exit 1
+fi
 
 # $ java -cp ${jar} edu.stanford.MarcToXML -h
 #  usage: edu.stanford.MarcToXML

--- a/bin/marc21_to_marcxml_test.sh
+++ b/bin/marc21_to_marcxml_test.sh
@@ -2,8 +2,31 @@
 
 SCRIPT_PATH=$( cd $(dirname $0) && pwd -P )
 export LD4P_ROOT=$( cd "${SCRIPT_PATH}/.." && pwd -P )
-export LD4P_CONFIG="${LD4P_ROOT}/config/config.sh"
-source ${LD4P_CONFIG}
+
+# Do not use the config/config.sh file because it gets linked
+# to the shared configs file on deployment.  This test script
+# must define some file IO paths specific for this test script so it
+# cannot collide with the real data paths on a deployed system.
+
+# ---
+# Utility paths and scripts
+
+export LD4P_LOGS="${LD4P_ROOT}/log"
+export LD4P_BIN="${LD4P_ROOT}/bin"
+export LD4P_LIB="${LD4P_ROOT}/lib"
+
+CONVERT_SCRIPT="${LD4P_BIN}/marc21_to_marcxml.sh"
+if [ ! -f "${CONVERT_SCRIPT}" ]; then
+    echo "Failed to locate convert script: ${CONVERT_SCRIPT}"
+    exit 1
+fi
+
+# ---
+# Data paths
+
+export LD4P_DATA="${LD4P_ROOT}/data"
+export LD4P_MARC="${LD4P_DATA}/Marc"
+export LD4P_MARCXML="${LD4P_DATA}/MarcXML"
 
 MARC_BIN="${LD4P_MARC}/one_record.mrc"
 if [ ! -f ${MARC_BIN} ]; then
@@ -11,12 +34,17 @@ if [ ! -f ${MARC_BIN} ]; then
     exit 1
 fi
 
+# ---
+# Run the test conversion and check the result
+
 ${CONVERT_SCRIPT} ${MARC_BIN}
 
-# Check the conversion worked, it should output this file.
+# The conversion should output this file:
 MARC_XML="${LD4P_MARCXML}/1629059.xml"
 if [ -s ${MARC_XML} ]; then
     echo "SUCCESS created MARC-XML file: ${MARC_XML}"
+    # remove this output file, so this test is idempotent
+    rm -f ${MARC_XML}
 else
     echo "FAILURE to create MARC-XML file: ${MARC_XML}"
     exit 1


### PR DESCRIPTION
Fix https://github.com/sul-dlss/ld4p-marc21-to-xml/issues/23

Deployed it to converter-dev and it seems to work, i.e.
```
$ cap dev deploy
# snipped out
$ cap dev deploy:run_test
Pseudo-terminal will not be allocated because stdin is not a terminal.
00:00 deploy:run_test
      01 cd /opt/app/ld4p/ld4p-marc21-to-xml/current && bin/marc21_to_marcxml_test.sh one_record.mrc
      01
      01 Converting MARC file:  /opt/app/ld4p/ld4p-marc21-to-xml/releases/20170309223031/data/Marc/one_record.mrc
      01 Output MARC-XML files: /opt/app/ld4p/ld4p-marc21-to-xml/releases/20170309223031/data/MarcXML/*.xml
      01 Logging conversion to: /opt/app/ld4p/ld4p-marc21-to-xml/releases/20170309223031/log/one_record_marc21-to-xml_20170309T143150.log
      01 Completed conversion.
      01
      01 SUCCESS created MARC-XML file: /opt/app/ld4p/ld4p-marc21-to-xml/releases/20170309223031/data/MarcXML/1629059.xml
    ✔ 01 ld4p@sul-ld4p-converter-dev.stanford.edu 1.639s
Pseudo-terminal will not be allocated because stdin is not a terminal.
```