### PR TITLE
Security check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 #install: - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 
 script:
-  - mvn test -B  &&  mvn cobertura:cobertura coveralls:report
+  - mvn verify &&  mvn cobertura:cobertura coveralls:report
 
 # save cache
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ To update Coveralls from the command line, try:
 
   `mvn clean test cobertura:cobertura coveralls:report -DrepoToken=yourcoverallsprojectrepositorytoken`
 
+### Security Vulnerability Reports
+
+To run the security vulnerability checks and view a report from the command line:
+```
+mvn clean verify
+ls -l xform-marc21-to-xml/target/dependency-check-report.html
+firefox xform-marc21-to-xml/target/dependency-check-report.html
+```
+
 ## Deployment
 
 Capistrano is used for deployment.

--- a/xform-marc21-to-xml/pom.xml
+++ b/xform-marc21-to-xml/pom.xml
@@ -63,6 +63,24 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>1.4.5</version>
+                <configuration>
+                    <failBuildOnCVSS>6</failBuildOnCVSS>
+                    <!-- skip artifacts not bundled in distribution (Provided and Runtime scope) -->
+                    <skipProvidedScope>true</skipProvidedScope>
+                    <skipRuntimeScope>true</skipRuntimeScope>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Fix #37 

- [x] enable a travis cache for the security vulnerability data

It seems to save the CVE data into the local maven repository, so travis can cache it because we already have a travis.ci cache enabled for the maven repository.  Although the CVE data expires after a week or something.  The location seems to be:
```
ls ~/.m2/repository/org/owasp/
antisamy/  dependency-check-core/  dependency-check-data/  dependency-check-maven/  dependency-check-parent/  dependency-check-utils/
```

- [x] identify a threshold for resolving a security vulnerability identified by the check
  - only CVSS > 6 will fail the build
  - ISO says that we have to patch anything with a NVD CVSS rating of 7.0 or above within 90 days, and a 9 or above is a 7 day patch requirement.
    - https://nvd.nist.gov/vuln-metrics/cvss
    - the CVSS v3 ratings match ISO’s ‘high’ and ‘critical’ criteria

- [ ] when the security vulnerabilities are resolved, ensure that travis runs the code coverage for coveralls

- Please review this PR - note that the current state of this PR is failing travis builds and that is actually the goal of this PR.  I know that’s unusual, but I actually want this PR to fail a travis build when there is a security vulnerability in the java dependencies.  So I need a review while it is failing a travis build.
- We should problably fix the vulnerability and have a second round of PR review on this PR, or we might decide on how to fix the vulnerability in a new PR (note that master branch currently contains the vulnerabilities identified by this PR).
