### PR TITLE
Upgrade maven-dependency-check and ojdbc

### DIFF
--- a/xform-marc21-to-xml/pom.xml
+++ b/xform-marc21-to-xml/pom.xml
@@ -66,7 +66,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>1.4.5</version>
+                <version>2.0.0</version>
                 <configuration>
                     <failBuildOnCVSS>6</failBuildOnCVSS>
                     <!-- skip artifacts not bundled in distribution (Provided and Runtime scope) -->
@@ -125,10 +125,11 @@
         <!-- Symphony is running Oracle 11.2 -->
         <!-- http://www.oracle.com/technetwork/apps-tech/jdbc-112010-090769.html -->
         <dependency>
-            <groupId>com.oracle.jdbc</groupId>
-            <artifactId>ojdbc6</artifactId>
-            <version>12.1.0.2</version>
+            <groupId>com.oracle.weblogic</groupId>
+            <artifactId>ojdbc7</artifactId>
+            <version>12.1.3-0-0</version>
         </dependency>
+
 
         <!--TESTS-->
 


### PR DESCRIPTION
Upgrading to latest version of `maven-dependency-check` solves the `No dependencies were identified that could be analyzed by dependency-check` error caused by upgrading the `exec-maven-plugin`. However, new ojdbc vulnerabilities were uncovered by upgrading the dependency-check, so we much upgrade to ojdbc7.